### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/CiviProxy/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>This is the companion extension to SYSTOPIA's CiviProxy security system</comments>
   <civix>

--- a/templates/CRM/Admin/Form/Setting/ProxySettings.tpl
+++ b/templates/CRM/Admin/Form/Setting/ProxySettings.tpl
@@ -13,15 +13,15 @@
       <div>
           <table id="core_settings" class="no-border">
             <tr>
-              <td class="label"><label for="proxy_enabled">{ts}CiviProxy enabled{/ts}&nbsp;<a onclick='CRM.help("{ts}CiviProxy enabled{/ts}", {literal}{"id":"id-proxy-enabled","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></label></td>
+              <td class="label"><label for="proxy_enabled">{ts}CiviProxy enabled{/ts}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute'}CiviProxy enabled{/ts}", {literal}{"id":"id-proxy-enabled","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></label></td>
               <td><input value="1" type="checkbox" id="proxy_enabled" name="proxy_enabled" {if $proxy_enabled}checked="checked"{/if} class="form-checkbox"/></td>
             </tr>
             <tr>
-              <td class="label">{$form.proxy_url.label}&nbsp;<a onclick='CRM.help("{ts}Proxy URL{/ts}", {literal}{"id":"id-proxy-url","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.proxy_url.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute'}Proxy URL{/ts}", {literal}{"id":"id-proxy-url","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.proxy_url.html}</td>
             </tr>
             <tr>
-              <td class="label">{$form.proxy_version.label}&nbsp;<a onclick='CRM.help("{ts}Proxy Version{/ts}", {literal}{"id":"id-proxy-version","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.proxy_version.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute'}Proxy Version{/ts}", {literal}{"id":"id-proxy-version","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.proxy_version.html}</td>
             </tr>
           </table>
@@ -35,7 +35,7 @@
       <div>
           <table id="core_settings" class="no-border">
             <tr>
-              <td class="label">{$form.custom_mailing_base.label}&nbsp;<a onclick='CRM.help("{ts}CiviMail: Custom pages{/ts}", {literal}{"id":"id-custom-mailing-base","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_mailing_base.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute'}CiviMail: Custom pages{/ts}", {literal}{"id":"id-custom-mailing-base","file":"CRM\/Admin\/Form\/Setting\/ProxySettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.custom_mailing_base.html}</td>
             </tr>
           </table>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.