### PR TITLE
Fix #5: CiviCRM Standalone: the image urls are not rewritten

### DIFF
--- a/CRM/Civiproxy/Mailer.php
+++ b/CRM/Civiproxy/Mailer.php
@@ -96,6 +96,11 @@ class CRM_Civiproxy_Mailer {
       $value
     );
     $value = preg_replace(
+      '#' . \Civi::paths()->getUrl('[civicrm.files]/', 'absolute') . '#i',
+      $proxy_base . '/file.php?id=',
+      $value
+    );
+    $value = preg_replace(
       "#{$system_base}civicrm/mosaico/img\?src=#i",
       $proxy_base . '/mosaico.php?id=',
       $value

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,7 +57,7 @@ parameters:
 		-
 			message: '#^Binary operation "\." between mixed and ''/file\.php\?id\='' results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: CRM/Civiproxy/Mailer.php
 
 		-
@@ -147,7 +147,7 @@ parameters:
 		-
 			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, array\<string\>\|string\|null given\.$#'
 			identifier: argument.type
-			count: 7
+			count: 8
 			path: CRM/Civiproxy/Mailer.php
 
 		-


### PR DESCRIPTION
This fixes #5 

The fix includes a cms agnostic fix for the files in the public or sites/default/files/civicrm/persist folder.

